### PR TITLE
ci: run nox with verbosity

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-versions: "3.11"
       - run: |
-          nox -e lint
+          nox -v -e lint
   nox-test:
     runs-on: ubuntu-latest
     defaults:
@@ -47,7 +47,7 @@ jobs:
         with:
           python-versions: "3.7, 3.8, 3.9, 3.10, 3.11"
       - run: |
-          nox -e test -p 3.7 3.8 3.9 3.10 3.11
+          nox -v -e test -p 3.7 3.8 3.9 3.10 3.11
       - name: Upload coverage
         uses: codecov/codecov-action@v3
   nox-test-36:
@@ -66,6 +66,6 @@ jobs:
         with:
           python-versions: "3.6"
       - run: |
-          nox -e test -p 3.6
+          nox -v -e test -p 3.6
       - name: Upload coverage
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
This shows the full `pip install` output, so we see what dependencies versions are being installed. This makes debugging easier.