### PR TITLE
Show missing lines in coverage report

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,8 @@ def test(session: nox.Session):
         "pytest",
         "--cov-branch",
         "--cov=antsibull_docs_parser",
+        "--cov-report",
+        "term-missing",
         *session.posargs,
     )
 


### PR DESCRIPTION
Since codecov isn't bothering to post comments, make sure that the missing lines can be found in CI.