### PR TITLE
CI: remove in valid GHA parameters, make pyre work in CI

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -59,7 +59,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: nox-test
-          working-directory: antsibull-docs-parser
+          directory: antsibull-docs-parser
   nox-test-36:
     # python3.6 is not available on ubuntu-latest
     runs-on: ubuntu-20.04
@@ -90,7 +90,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: nox-test-36
-          working-directory: antsibull-docs-parser
+          directory: antsibull-docs-parser
   nox-vectors:
     runs-on: ubuntu-latest
     defaults:

--- a/noxfile.py
+++ b/noxfile.py
@@ -92,7 +92,8 @@ def codeqa(session: nox.Session):
 
 @nox.session
 def typing(session: nox.Session):
-    install(session, ".[typing]", editable=True)
+    # pyre does not work when we don't install ourself in editable mode 🙄.
+    install(session, "-e", ".[typing]")
     session.run("mypy", "src/antsibull_docs_parser")
     session.run("pyre", "--source-directory", "src")
 


### PR DESCRIPTION
- The `codecov/codecov-action` GHA action does not support a `working-directory` option, it's called `directory` instead.
- Pyre does not work when the project isn't installed in editable mode (https://github.com/ansible-community/antsibull-docs/pull/137).