### PR TITLE
Use 'hatch version' instead of manually updating the version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -177,7 +177,9 @@ def bump(session: nox.Session):
                 f"Either {fragment_file} must already exist, or two positional arguments must be provided."
             )
     install(session, "antsibull-changelog[toml]", "hatch")
-    _repl_version(session, version)
+    current_version = session.run("hatch", "version", silent=True).strip()
+    if version != current_version:
+        session.run("hatch", "version", version)
     if len(session.posargs) > 1:
         fragment = session.run(
             "python",
@@ -223,7 +225,6 @@ def publish(session: nox.Session):
     check_no_modifications(session)
     install(session, "hatch")
     session.run("hatch", "publish", *session.posargs)
-    version = session.run("hatch", "version", silent=True).strip()
-    _repl_version(session, f"{version}.post0")
+    session.run("hatch", "version", "post")
     session.run("git", "add", "pyproject.toml", external=True)
     session.run("git", "commit", "-m", "Post-release version bump.", external=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -110,17 +110,6 @@ def create_vectors(session: nox.Session):
         )
 
 
-def _repl_version(session: nox.Session, new_version: str):
-    with open("pyproject.toml", "r+") as fp:
-        lines = tuple(fp)
-        fp.seek(0)
-        for line in lines:
-            if line.startswith("version = "):
-                line = f'version = "{new_version}"\n'
-            fp.write(line)
-        fp.truncate()
-
-
 def test_no_modifications(session: nox.Session) -> bool:
     modified = session.run(
         "git",
@@ -189,7 +178,13 @@ def bump(session: nox.Session):
         )
         with open(fragment_file, "w") as fp:
             print(fragment, file=fp)
-        session.run("git", "add", "pyproject.toml", fragment_file, external=True)
+        session.run(
+            "git",
+            "add",
+            "src/antsibull_docs_parser/__init__.py",
+            fragment_file,
+            external=True,
+        )
         session.run("git", "commit", "-m", f"Prepare {version}.", external=True)
     session.run("antsibull-changelog", "release")
     session.run(
@@ -198,9 +193,9 @@ def bump(session: nox.Session):
         "CHANGELOG.rst",
         "changelogs/changelog.yaml",
         "changelogs/fragments/",
-        # pyproject.toml is not committed in the last step
+        # __init__.py is not committed in the last step
         # when the release_summary fragment is created manually
-        "pyproject.toml",
+        "src/antsibull_docs_parser/__init__.py",
         external=True,
     )
     install(session, ".")  # Smoke test
@@ -226,5 +221,5 @@ def publish(session: nox.Session):
     install(session, "hatch")
     session.run("hatch", "publish", *session.posargs)
     session.run("hatch", "version", "post")
-    session.run("git", "add", "pyproject.toml", external=True)
+    session.run("git", "add", "src/antsibull_docs_parser/__init__.py", external=True)
     session.run("git", "commit", "-m", "Post-release version bump.", external=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -186,7 +186,7 @@ def bump(session: nox.Session):
             external=True,
         )
         session.run("git", "commit", "-m", f"Prepare {version}.", external=True)
-    session.run("antsibull-changelog", "release")
+    session.run("antsibull-changelog", "release", "--version", version)
     session.run(
         "git",
         "add",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "antsibull-docs-parser"
-version = "1.0.0.post0"
+dynamic = ["version"]
 description = "Python library for processing Ansible documentation markup"
 readme = "README.md"
 requires-python = ">=3.6.1"
@@ -73,6 +73,9 @@ dev = [
     # misc
     "nox",
 ]
+
+[tool.hatch.version]
+path = "src/antsibull_docs_parser/__init__.py"
 
 [tool.isort]
 profile = "black"

--- a/src/antsibull_docs_parser/__init__.py
+++ b/src/antsibull_docs_parser/__init__.py
@@ -2,3 +2,11 @@
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2020, Ansible Project
+
+"""
+Library for processing Ansible documentation markup.
+"""
+
+__version__ = "1.0.0.post0"
+
+__all__ = ("__version__",)


### PR DESCRIPTION
We did this change to antsibull-docs some time ago. I had to fix that a bit today with https://github.com/ansible-community/antsibull-docs/commit/676780b99912f5e9d8b206b14a65ed03d8405919. This PR applies the noxfile changes to this project as well.