### PR TITLE
Make whitespace handling configurable; always remove some space around HORIZONTALLINE

### DIFF
--- a/changelogs/fragments/54-whitespace.yml
+++ b/changelogs/fragments/54-whitespace.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Allow to determine how to handle whitespace during parsing with the new ``whitespace`` option (https://github.com/ansible-community/antsibull-docs-parser/pull/54)."
+  - "Always remove some whitespace around ``HORIZONTALLINE`` (https://github.com/ansible-community/antsibull-docs-parser/pull/54)."

--- a/test-vectors.yaml
+++ b/test-vectors.yaml
@@ -174,29 +174,29 @@ test_vectors:
     source: |-
       foo HORIZONTALLINE bar
     html: |-
-      <p>foo <hr/> bar</p>
+      <p>foo<hr/>bar</p>
     html_plain: |-
-      <p>foo <hr> bar</p>
+      <p>foo<hr>bar</p>
     md: |-
-      foo <hr> bar
+      foo<hr>bar
     rst: |-
-      foo 
+      foo
 
       .. raw:: html
 
         <hr>
 
-       bar
+      bar
     ansible_doc_text: |-
-      foo 
+      foo
       -------------
-       bar
+      bar
     rst_plain: |-
-      foo 
+      foo
 
       ------------
 
-       bar
+      bar
   semantic_markup:
     source: |-
       foo E(FOOBAR) bar P(foo.bar.baz#bam) has value V( foo\),bar\\bam ).
@@ -1544,35 +1544,35 @@ test_vectors:
       whitespace: ignore
     html: "<p>Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! <b>foo\
       \  \t bar\nbaz \r bam</b> \n <code class='docutils literal notranslate'>foo\
-      \  \t bar\nbaz \r bam</code> \n <hr/> x <span class=\"error\">ERROR while parsing:
+      \  \t bar\nbaz \r bam</code> \n<hr/>x <span class=\"error\">ERROR while parsing:
       While parsing \"M(föø  \\t b\\nz \\r m)\" at index 125: Module name \"föø  \\\
       t b\\nz \\r m\" is not a FQCN</span>\n   <em>  </em><code class='docutils literal
       notranslate'>  </code><b>    </b><code class=\"xref std std-envvar literal notranslate\"\
       >    </code></p>"
     html_plain: "<p>Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\
-      \n! <b>foo  \t bar\nbaz \r bam</b> \n <code>foo  \t bar\nbaz \r bam</code> \n
-      <hr> x <span class=\"error\">ERROR while parsing: While parsing \"M(föø  \\\
-      t b\\nz \\r m)\" at index 125: Module name \"föø  \\t b\\nz \\r m\" is not a
-      FQCN</span>\n   <em>  </em><code>  </code><b>    </b><code>    </code></p>"
+      \n! <b>foo  \t bar\nbaz \r bam</b> \n <code>foo  \t bar\nbaz \r bam</code> \n\
+      <hr>x <span class=\"error\">ERROR while parsing: While parsing \"M(föø  \\t
+      b\\nz \\r m)\" at index 125: Module name \"föø  \\t b\\nz \\r m\" is not a FQCN</span>\n
+        <em>  </em><code>  </code><b>    </b><code>    </code></p>"
     md: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n\\! <b>foo\
-      \  \t bar\nbaz \r bam</b> \n <code>foo  \t bar\nbaz \r bam</code> \n <hr> x
-      <b>ERROR while parsing</b>: While parsing \\\"M\\(föø  \\\\t b\\\\nz \\\\r m\\\
-      )\\\" at index 125\\: Module name \\\"föø  \\\\t b\\\\nz \\\\r m\\\" is not
-      a FQCN\n   <em>  </em><code>  </code><b>    </b><code>    </code>"
+      \  \t bar\nbaz \r bam</b> \n <code>foo  \t bar\nbaz \r bam</code> \n<hr>x <b>ERROR
+      while parsing</b>: While parsing \\\"M\\(föø  \\\\t b\\\\nz \\\\r m\\)\\\" at
+      index 125\\: Module name \\\"föø  \\\\t b\\\\nz \\\\r m\\\" is not a FQCN\n
+        <em>  </em><code>  </code><b>    </b><code>    </code>"
     rst: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! \\ :strong:`foo\
-      \  \t bar\nbaz \r bam`\\  \n \\ :literal:`foo  \t bar\nbaz \r bam`\\  \n \n\n\
-      .. raw:: html\n\n  <hr>\n\n x \\ :strong:`ERROR while parsing`\\ : While parsing
+      \  \t bar\nbaz \r bam`\\  \n \\ :literal:`foo  \t bar\nbaz \r bam`\\  \n\n\n\
+      .. raw:: html\n\n  <hr>\n\nx \\ :strong:`ERROR while parsing`\\ : While parsing
       \"M(föø  \\\\t b\\\\nz \\\\r m)\" at index 125: Module name \"föø  \\\\t b\\\
       \\nz \\\\r m\" is not a FQCN\\ \n   \\ :emphasis:`  `\\ \\ :literal:`  `\\ \\
       :strong:`\\     \\ `\\ \\ :envvar:`\\     \\ `\\ "
     rst_plain: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n!
       \\ :strong:`foo  \t bar\nbaz \r bam`\\  \n \\ :literal:`foo  \t bar\nbaz \r
-      bam`\\  \n \n\n------------\n\n x \\ :strong:`ERROR while parsing`\\ : While
-      parsing \"M(föø  \\\\t b\\\\nz \\\\r m)\" at index 125: Module name \"föø  \\\
-      \\t b\\\\nz \\\\r m\" is not a FQCN\\ \n   \\ :emphasis:`  `\\ \\ :literal:`  `\\
-      \\ :strong:`\\     \\ `\\ \\ :envvar:`\\     \\ `\\ "
+      bam`\\  \n\n\n------------\n\nx \\ :strong:`ERROR while parsing`\\ : While parsing
+      \"M(föø  \\\\t b\\\\nz \\\\r m)\" at index 125: Module name \"föø  \\\\t b\\\
+      \\nz \\\\r m\" is not a FQCN\\ \n   \\ :emphasis:`  `\\ \\ :literal:`  `\\ \\
+      :strong:`\\     \\ `\\ \\ :envvar:`\\     \\ `\\ "
     ansible_doc_text: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\
-      \n\n! *foo  \t bar\nbaz \r bam* \n `foo  \t bar\nbaz \r bam' \n \n-------------\n
+      \n\n! *foo  \t bar\nbaz \r bam* \n `foo  \t bar\nbaz \r bam' \n\n-------------\n\
       x [[ERROR while parsing: While parsing \"M(föø  \\t b\\nz \\r m)\" at index
       125: Module name \"föø  \\t b\\nz \\r m\" is not a FQCN]]\n   `  '`  '*    *`
          '"
@@ -1583,11 +1583,11 @@ test_vectors:
     parse_opts:
       whitespace: strip
     html: |-
-      <p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b> <code class='docutils literal notranslate'>foo    bar baz   bam</code> <hr/> x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>   <em>  </em><code class='docutils literal notranslate'>  </code><b>    </b><code class="xref std std-envvar literal notranslate">    </code></p>
+      <p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b> <code class='docutils literal notranslate'>foo    bar baz   bam</code> <hr/>x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>   <em>  </em><code class='docutils literal notranslate'>  </code><b>    </b><code class="xref std std-envvar literal notranslate">    </code></p>
     html_plain: |-
-      <p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b> <code>foo    bar baz   bam</code> <hr> x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>   <em>  </em><code>  </code><b>    </b><code>    </code></p>
+      <p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b> <code>foo    bar baz   bam</code> <hr>x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>   <em>  </em><code>  </code><b>    </b><code>    </code></p>
     md: |-
-      Foo bar baz Welcome to white space fun \! <b>foo bar baz bam</b> <code>foo    bar baz   bam</code> <hr> x <b>ERROR while parsing</b>: While parsing \"M\(föø  \\t b\\nz \\r m\)\" at index 125\: Module name \"föø b z m\" is not a FQCN   <em>  </em><code>  </code><b>    </b><code>    </code>
+      Foo bar baz Welcome to white space fun \! <b>foo bar baz bam</b> <code>foo    bar baz   bam</code> <hr>x <b>ERROR while parsing</b>: While parsing \"M\(föø  \\t b\\nz \\r m\)\" at index 125\: Module name \"föø b z m\" is not a FQCN   <em>  </em><code>  </code><b>    </b><code>    </code>
     rst: |-
       Foo bar baz Welcome to white space fun ! \ :strong:`foo bar baz bam`\  \ :literal:`foo    bar baz   bam`\  
 
@@ -1595,17 +1595,17 @@ test_vectors:
 
         <hr>
 
-       x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\    \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
+      x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\    \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
     rst_plain: |-
       Foo bar baz Welcome to white space fun ! \ :strong:`foo bar baz bam`\  \ :literal:`foo    bar baz   bam`\  
 
       ------------
 
-       x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\    \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
+      x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\    \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
     ansible_doc_text: |-
       Foo bar baz Welcome to white space fun ! *foo bar baz bam* `foo    bar baz   bam' 
       -------------
-       x [[ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN]]   `  '`  '*    *`    '
+      x [[ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN]]   `  '`  '*    *`    '
   whitespace_keep_single_newlines:
     source: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! B(foo\
       \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(föø\
@@ -1619,7 +1619,7 @@ test_vectors:
       fun
       ! <b>foo bar baz bam</b>
       <code class='docutils literal notranslate'>foo    bar baz   bam</code>
-      <hr/> x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>
+      <hr/>x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>
         <em>  </em><code class='docutils literal notranslate'>  </code><b>    </b><code class="xref std std-envvar literal notranslate">    </code></p>
     html_plain: |-
       <p>Foo bar baz
@@ -1628,7 +1628,7 @@ test_vectors:
       fun
       ! <b>foo bar baz bam</b>
       <code>foo    bar baz   bam</code>
-      <hr> x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>
+      <hr>x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>
         <em>  </em><code>  </code><b>    </b><code>    </code></p>
     md: |-
       Foo bar baz
@@ -1637,7 +1637,7 @@ test_vectors:
       fun
       \! <b>foo bar baz bam</b>
       <code>foo    bar baz   bam</code>
-      <hr> x <b>ERROR while parsing</b>: While parsing \"M\(föø  \\t b\\nz \\r m\)\" at index 125\: Module name \"föø b z m\" is not a FQCN
+      <hr>x <b>ERROR while parsing</b>: While parsing \"M\(föø  \\t b\\nz \\r m\)\" at index 125\: Module name \"föø b z m\" is not a FQCN
         <em>  </em><code>  </code><b>    </b><code>    </code>
     rst: |-
       Foo bar baz
@@ -1652,7 +1652,7 @@ test_vectors:
 
         <hr>
 
-       x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\ 
+      x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\ 
         \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
     rst_plain: |-
       Foo bar baz
@@ -1665,7 +1665,7 @@ test_vectors:
 
       ------------
 
-       x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\ 
+      x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\ 
         \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
     ansible_doc_text: |-
       Foo bar baz
@@ -1676,5 +1676,5 @@ test_vectors:
       `foo    bar baz   bam'
 
       -------------
-       x [[ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN]]
+      x [[ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN]]
         `  '`  '*    *`    '

--- a/test-vectors.yaml
+++ b/test-vectors.yaml
@@ -14,8 +14,10 @@ test_vectors:
     rst_plain: ''
   empty_content:
     source: ['']
-    html: <p></p>
-    html_plain: <p></p>
+    html: |-
+      <p></p>
+    html_plain: |-
+      <p></p>
     md: ' '
     rst: '\ '
     ansible_doc_text: ''
@@ -31,30 +33,27 @@ test_vectors:
       This is a <code>test</code> <em>module</em> <b>markup</b>\.
     rst: |-
       This is a \ :literal:`test`\  \ :emphasis:`module`\  \ :strong:`markup`\ .
-    ansible_doc_text: This is a `test' `module' *markup*.
-    rst_plain: This is a \ :literal:`test`\  \ :emphasis:`module`\  \ :strong:`markup`\
-      .
+    ansible_doc_text: |-
+      This is a `test' `module' *markup*.
+    rst_plain: |-
+      This is a \ :literal:`test`\  \ :emphasis:`module`\  \ :strong:`markup`\ .
   empty_tags:
     source: |-
       C() I() B() C() U() L(,) L(foo,) L(,bar) R(,) V() O() RV() E()
-    html: <p><code class='docutils literal notranslate'></code> <em></em> <b></b>
-      <code class='docutils literal notranslate'></code> <a href=''></a> <a href=''></a>
-      <a href=''>foo</a> <a href='bar'></a> <span class='module'></span> <code class="ansible-value
-      literal notranslate"></code> <code class="ansible-option literal notranslate"><strong></strong></code>
-      <code class="ansible-return-value literal notranslate"></code> <code class="xref
-      std std-envvar literal notranslate"></code></p>
-    html_plain: <p><code></code> <em></em> <b></b> <code></code> <a href=''></a> <a
-      href=''></a> <a href=''>foo</a> <a href='bar'></a> <span></span> <code></code>
-      <code><strong></strong></code> <code></code> <code></code></p>
-    md: <code></code> <em></em> <b></b> <code></code> []() []() [foo]() [](bar)  <code></code>
-      <code><strong></strong></code> <code></code> <code></code>
+    html: |-
+      <p><code class='docutils literal notranslate'></code> <em></em> <b></b> <code class='docutils literal notranslate'></code> <a href=''></a> <a href=''></a> <a href=''>foo</a> <a href='bar'></a> <span class='module'></span> <code class="ansible-value literal notranslate"></code> <code class="ansible-option literal notranslate"><strong></strong></code> <code class="ansible-return-value literal notranslate"></code> <code class="xref std std-envvar literal notranslate"></code></p>
+    html_plain: |-
+      <p><code></code> <em></em> <b></b> <code></code> <a href=''></a> <a href=''></a> <a href=''>foo</a> <a href='bar'></a> <span></span> <code></code> <code><strong></strong></code> <code></code> <code></code></p>
+    md: |-
+      <code></code> <em></em> <b></b> <code></code> []() []() [foo]() [](bar)  <code></code> <code><strong></strong></code> <code></code> <code></code>
     rst: '\ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\ `\    foo  \
       :ref:`\  <>`\  \ :ansval:`\ `\  \ :ansopt:`\ `\  \ :ansretval:`\ `\  \ :envvar:`\
       `\ '
     rst_plain: '\ :literal:`\ `\  \ :emphasis:`\ `\  \ :strong:`\ `\  \ :literal:`\
       `\    foo  \ :ref:`\  <>`\  \ :literal:`\ `\  \ :literal:`\ `\  \ :literal:`\
       `\  \ :envvar:`\ `\ '
-    ansible_doc_text: "`' `' ** `'   <> foo <>  <bar>  `' `' `' `'"
+    ansible_doc_text: |-
+      `' `' ** `'   <> foo <>  <bar>  `' `' `' `'
   module:
     source: |-
       The M(a.b.c) module.
@@ -72,8 +71,10 @@ test_vectors:
         https://docs.ansible.com/ansible/devel/collections/{plugin_fqcn_slashes}_{plugin_type}.html
     rst: |-
       The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
-    ansible_doc_text: The [a.b.c] module.
-    rst_plain: The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
+    ansible_doc_text: |-
+      The [a.b.c] module.
+    rst_plain: |-
+      The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
   module_no_link:
     source: |-
       The M(a.b.c) module.
@@ -85,8 +86,10 @@ test_vectors:
       The a\.b\.c module\.
     rst: |-
       The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
-    ansible_doc_text: The [a.b.c] module.
-    rst_plain: The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
+    ansible_doc_text: |-
+      The [a.b.c] module.
+    rst_plain: |-
+      The \ :ref:`a.b.c <ansible_collections.a.b.c_module>`\  module.
   plugin:
     source: |-
       The P(a.b.c#lookup) lookup plugin.
@@ -104,8 +107,10 @@ test_vectors:
         https://docs.ansible.com/ansible/devel/collections/{plugin_fqcn_slashes}_{plugin_type}.html
     rst: |-
       The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
-    ansible_doc_text: The [a.b.c] lookup plugin.
-    rst_plain: The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
+    ansible_doc_text: |-
+      The [a.b.c] lookup plugin.
+    rst_plain: |-
+      The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
   plugin_no_link:
     source: |-
       The P(a.b.c#lookup) lookup plugin.
@@ -117,8 +122,10 @@ test_vectors:
       The a\.b\.c lookup plugin\.
     rst: |-
       The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
-    ansible_doc_text: The [a.b.c] lookup plugin.
-    rst_plain: The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
+    ansible_doc_text: |-
+      The [a.b.c] lookup plugin.
+    rst_plain: |-
+      The \ :ref:`a.b.c <ansible_collections.a.b.c_lookup>`\  lookup plugin.
   link_and_url:
     source: |-
       An URL U(https://example.com) and L(a link, https://example.org).
@@ -159,9 +166,10 @@ test_vectors:
       A RST reference\.
     rst: |-
       A \ :ref:`RST reference <ansible_collections.community.general.ufw_module>`\ .
-    ansible_doc_text: A RST reference.
-    rst_plain: A \ :ref:`RST reference <ansible_collections.community.general.ufw_module>`\
-      .
+    ansible_doc_text: |-
+      A RST reference.
+    rst_plain: |-
+      A \ :ref:`RST reference <ansible_collections.community.general.ufw_module>`\ .
   horizontal_line:
     source: |-
       foo HORIZONTALLINE bar
@@ -200,9 +208,10 @@ test_vectors:
       foo <code>FOOBAR</code> bar foo\.bar\.baz has value <code> foo\)\,bar\\bam </code>\.
     rst: |-
       foo \ :envvar:`FOOBAR`\  bar \ :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_bam>`\  has value \ :ansval:`\  foo),bar\\bam \ `\ .
-    ansible_doc_text: foo `FOOBAR' bar [foo.bar.baz] has value ` foo),bar\bam '.
-    rst_plain: foo \ :envvar:`FOOBAR`\  bar \ :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_bam>`\  has
-      value \ :literal:`\  foo),bar\\bam \ `\ .
+    ansible_doc_text: |-
+      foo `FOOBAR' bar [foo.bar.baz] has value ` foo),bar\bam '.
+    rst_plain: |-
+      foo \ :envvar:`FOOBAR`\  bar \ :ref:`foo.bar.baz <ansible_collections.foo.bar.baz_bam>`\  has value \ :literal:`\  foo),bar\\bam \ `\ .
   option_name_no_current_plugin:
     source:
       - |-
@@ -1527,3 +1536,145 @@ test_vectors:
       \ :strong:`ERROR while parsing`\ : While parsing "C(foo" at index 1 of paragraph 2: Cannot find closing ")" after last parameter\ 
 
       \ :strong:`ERROR while parsing`\ : While parsing "R(foo,bar" at index 1 of paragraph 3: Cannot find closing ")" after last parameter\ 
+  whitespace_ignore:
+    source: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! B(foo\
+      \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(föø\
+      \  \t b\nz \r m)\n   I(  )C(  )B(    )E(    )"
+    parse_opts:
+      whitespace: ignore
+    html: "<p>Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! <b>foo\
+      \  \t bar\nbaz \r bam</b> \n <code class='docutils literal notranslate'>foo\
+      \  \t bar\nbaz \r bam</code> \n <hr/> x <span class=\"error\">ERROR while parsing:
+      While parsing \"M(föø  \\t b\\nz \\r m)\" at index 125: Module name \"föø  \\\
+      t b\\nz \\r m\" is not a FQCN</span>\n   <em>  </em><code class='docutils literal
+      notranslate'>  </code><b>    </b><code class=\"xref std std-envvar literal notranslate\"\
+      >    </code></p>"
+    html_plain: "<p>Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\
+      \n! <b>foo  \t bar\nbaz \r bam</b> \n <code>foo  \t bar\nbaz \r bam</code> \n
+      <hr> x <span class=\"error\">ERROR while parsing: While parsing \"M(föø  \\\
+      t b\\nz \\r m)\" at index 125: Module name \"föø  \\t b\\nz \\r m\" is not a
+      FQCN</span>\n   <em>  </em><code>  </code><b>    </b><code>    </code></p>"
+    md: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n\\! <b>foo\
+      \  \t bar\nbaz \r bam</b> \n <code>foo  \t bar\nbaz \r bam</code> \n <hr> x
+      <b>ERROR while parsing</b>: While parsing \\\"M\\(föø  \\\\t b\\\\nz \\\\r m\\\
+      )\\\" at index 125\\: Module name \\\"föø  \\\\t b\\\\nz \\\\r m\\\" is not
+      a FQCN\n   <em>  </em><code>  </code><b>    </b><code>    </code>"
+    rst: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! \\ :strong:`foo\
+      \  \t bar\nbaz \r bam`\\  \n \\ :literal:`foo  \t bar\nbaz \r bam`\\  \n \n\n\
+      .. raw:: html\n\n  <hr>\n\n x \\ :strong:`ERROR while parsing`\\ : While parsing
+      \"M(föø  \\\\t b\\\\nz \\\\r m)\" at index 125: Module name \"föø  \\\\t b\\\
+      \\nz \\\\r m\" is not a FQCN\\ \n   \\ :emphasis:`  `\\ \\ :literal:`  `\\ \\
+      :strong:`\\     \\ `\\ \\ :envvar:`\\     \\ `\\ "
+    rst_plain: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n!
+      \\ :strong:`foo  \t bar\nbaz \r bam`\\  \n \\ :literal:`foo  \t bar\nbaz \r
+      bam`\\  \n \n\n------------\n\n x \\ :strong:`ERROR while parsing`\\ : While
+      parsing \"M(föø  \\\\t b\\\\nz \\\\r m)\" at index 125: Module name \"föø  \\\
+      \\t b\\\\nz \\\\r m\" is not a FQCN\\ \n   \\ :emphasis:`  `\\ \\ :literal:`  `\\
+      \\ :strong:`\\     \\ `\\ \\ :envvar:`\\     \\ `\\ "
+    ansible_doc_text: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\
+      \n\n! *foo  \t bar\nbaz \r bam* \n `foo  \t bar\nbaz \r bam' \n \n-------------\n
+      x [[ERROR while parsing: While parsing \"M(föø  \\t b\\nz \\r m)\" at index
+      125: Module name \"föø  \\t b\\nz \\r m\" is not a FQCN]]\n   `  '`  '*    *`
+         '"
+  whitespace_strip:
+    source: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! B(foo\
+      \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(föø\
+      \  \t b\nz \r m)\n   I(  )C(  )B(    )E(    )"
+    parse_opts:
+      whitespace: strip
+    html: |-
+      <p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b> <code class='docutils literal notranslate'>foo    bar baz   bam</code> <hr/> x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>   <em>  </em><code class='docutils literal notranslate'>  </code><b>    </b><code class="xref std std-envvar literal notranslate">    </code></p>
+    html_plain: |-
+      <p>Foo bar baz Welcome to white space fun ! <b>foo bar baz bam</b> <code>foo    bar baz   bam</code> <hr> x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>   <em>  </em><code>  </code><b>    </b><code>    </code></p>
+    md: |-
+      Foo bar baz Welcome to white space fun \! <b>foo bar baz bam</b> <code>foo    bar baz   bam</code> <hr> x <b>ERROR while parsing</b>: While parsing \"M\(föø  \\t b\\nz \\r m\)\" at index 125\: Module name \"föø b z m\" is not a FQCN   <em>  </em><code>  </code><b>    </b><code>    </code>
+    rst: |-
+      Foo bar baz Welcome to white space fun ! \ :strong:`foo bar baz bam`\  \ :literal:`foo    bar baz   bam`\  
+
+      .. raw:: html
+
+        <hr>
+
+       x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\    \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
+    rst_plain: |-
+      Foo bar baz Welcome to white space fun ! \ :strong:`foo bar baz bam`\  \ :literal:`foo    bar baz   bam`\  
+
+      ------------
+
+       x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\    \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
+    ansible_doc_text: |-
+      Foo bar baz Welcome to white space fun ! *foo bar baz bam* `foo    bar baz   bam' 
+      -------------
+       x [[ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN]]   `  '`  '*    *`    '
+  whitespace_keep_single_newlines:
+    source: "Foo  bar\tbaz \n   Welcome  to  \n\r\n\r white\tspace\nfun\n\n\n! B(foo\
+      \  \t bar\nbaz \r bam) \n C(foo  \t bar\nbaz \r bam) \n HORIZONTALLINE x M(föø\
+      \  \t b\nz \r m)\n   I(  )C(  )B(    )E(    )"
+    parse_opts:
+      whitespace: keep_single_newlines
+    html: |-
+      <p>Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! <b>foo bar baz bam</b>
+      <code class='docutils literal notranslate'>foo    bar baz   bam</code>
+      <hr/> x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>
+        <em>  </em><code class='docutils literal notranslate'>  </code><b>    </b><code class="xref std std-envvar literal notranslate">    </code></p>
+    html_plain: |-
+      <p>Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! <b>foo bar baz bam</b>
+      <code>foo    bar baz   bam</code>
+      <hr> x <span class="error">ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN</span>
+        <em>  </em><code>  </code><b>    </b><code>    </code></p>
+    md: |-
+      Foo bar baz
+      Welcome to
+      white space
+      fun
+      \! <b>foo bar baz bam</b>
+      <code>foo    bar baz   bam</code>
+      <hr> x <b>ERROR while parsing</b>: While parsing \"M\(föø  \\t b\\nz \\r m\)\" at index 125\: Module name \"föø b z m\" is not a FQCN
+        <em>  </em><code>  </code><b>    </b><code>    </code>
+    rst: |-
+      Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! \ :strong:`foo bar baz bam`\ 
+      \ :literal:`foo    bar baz   bam`\ 
+
+
+      .. raw:: html
+
+        <hr>
+
+       x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\ 
+        \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
+    rst_plain: |-
+      Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! \ :strong:`foo bar baz bam`\ 
+      \ :literal:`foo    bar baz   bam`\ 
+
+
+      ------------
+
+       x \ :strong:`ERROR while parsing`\ : While parsing "M(föø  \\t b\\nz \\r m)" at index 125: Module name "föø b z m" is not a FQCN\ 
+        \ :emphasis:`  `\ \ :literal:`  `\ \ :strong:`\     \ `\ \ :envvar:`\     \ `\ 
+    ansible_doc_text: |-
+      Foo bar baz
+      Welcome to
+      white space
+      fun
+      ! *foo bar baz bam*
+      `foo    bar baz   bam'
+
+      -------------
+       x [[ERROR while parsing: While parsing "M(föø  \t b\nz \r m)" at index 125: Module name "föø b z m" is not a FQCN]]
+        `  '`  '*    *`    '

--- a/tests/unit/create-vectors.py
+++ b/tests/unit/create-vectors.py
@@ -24,8 +24,12 @@ from antsibull_docs_parser.rst import to_rst, to_rst_plain
 
 
 def add(test_data: t.Dict[str, t.Any], key: str, value: t.Any) -> None:
-    if isinstance(value, str):
-        if "\n" in value:
+    if isinstance(value, str) and value:
+        if "\r" in value or "\t" in value:
+            pass
+        elif "\n" in value:
+            value = LiteralScalarString(value)
+        elif value == value.rstrip(" "):
             value = LiteralScalarString(value)
     test_data[key] = value
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -126,7 +126,6 @@ TEST_PARSE_DATA: t.List[
                 dom.TextPart(text=" ) "),
                 dom.URLPart(url="https://example.com/?foo=bar"),
                 dom.HorizontalLinePart(),
-                dom.TextPart(text=" "),
                 dom.LinkPart(text="foo", url="https://bar.com"),
                 dom.TextPart(text=" "),
                 dom.RSTRefPart(text=" a", ref="b "),
@@ -154,7 +153,6 @@ TEST_PARSE_DATA: t.List[
                     source="U(https://example.com/?foo=bar)",
                 ),
                 dom.HorizontalLinePart(source="HORIZONTALLINE"),
-                dom.TextPart(text=" ", source=" "),
                 dom.LinkPart(
                     text="foo",
                     url="https://bar.com",
@@ -183,7 +181,6 @@ TEST_PARSE_DATA: t.List[
                 dom.TextPart(text=" ) "),
                 dom.URLPart(url="https://example.com/?foo=bar"),
                 dom.HorizontalLinePart(),
-                dom.TextPart(text=" "),
                 dom.LinkPart(text="foo", url="https://bar.com"),
                 dom.TextPart(text=" "),
                 dom.RSTRefPart(text=" a", ref="b "),

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -8,7 +8,93 @@ import typing as t
 import pytest
 
 from antsibull_docs_parser import dom
-from antsibull_docs_parser.parser import CommandParser, Context, Parser, parse
+from antsibull_docs_parser.parser import (
+    CommandParser,
+    Context,
+    Parser,
+    Whitespace,
+    _process_whitespace,
+    parse,
+)
+
+PROCESS_WHITESPACE_DATA: t.List[t.Tuple[str, bool, bool, str, str]] = [
+    (
+        "",
+        False,
+        False,
+        "",
+        "",
+    ),
+    (
+        " ",
+        False,
+        False,
+        " ",
+        " ",
+    ),
+    (
+        "  ",
+        False,
+        False,
+        " ",
+        " ",
+    ),
+    (
+        "\n",
+        False,
+        False,
+        " ",
+        "\n",
+    ),
+    (
+        "\n",
+        False,
+        True,
+        " ",
+        " ",
+    ),
+    (
+        " \n ",
+        False,
+        False,
+        " ",
+        "\n",
+    ),
+    (
+        "Foo \n\r\t\n\r Bar",
+        False,
+        False,
+        "Foo Bar",
+        "Foo\nBar",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "text, code_environment, no_newlines, result_strip, result_keep_single_newlines",
+    PROCESS_WHITESPACE_DATA,
+)
+def test__process_whitespace(
+    text, code_environment, no_newlines, result_strip, result_keep_single_newlines
+):
+    res_strip = _process_whitespace(
+        text,
+        whitespace=Whitespace.STRIP,
+        code_environment=code_environment,
+        no_newlines=no_newlines,
+    )
+    print(repr(res_strip))
+    assert res_strip == result_strip
+
+    res_keep_single_newlines = _process_whitespace(
+        text,
+        whitespace=Whitespace.KEEP_SINGLE_NEWLINES,
+        code_environment=code_environment,
+        no_newlines=no_newlines,
+    )
+    print(repr(res_keep_single_newlines))
+    assert res_keep_single_newlines == result_keep_single_newlines
+
 
 TEST_PARSE_DATA: t.List[
     t.Tuple[

--- a/tests/unit/vectors.py
+++ b/tests/unit/vectors.py
@@ -7,7 +7,7 @@ import typing as t
 
 from antsibull_docs_parser import dom
 from antsibull_docs_parser.format import LinkProvider
-from antsibull_docs_parser.parser import Context
+from antsibull_docs_parser.parser import Context, Whitespace
 
 VECTORS_FILE = "test-vectors.yaml"
 
@@ -79,6 +79,12 @@ def get_context_parse_opts(test_data: t.Mapping[str, t.Any]):
             ]
         if "helpfulErrors" in test_data["parse_opts"]:
             parse_opts["helpful_errors"] = test_data["parse_opts"]["helpfulErrors"]
+        if "whitespace" in test_data["parse_opts"]:
+            parse_opts["whitespace"] = {
+                "ignore": Whitespace.IGNORE,
+                "strip": Whitespace.STRIP,
+                "keep_single_newlines": Whitespace.KEEP_SINGLE_NEWLINES,
+            }[test_data["parse_opts"]["whitespace"]]
     return Context(**context_opts), parse_opts
 
 


### PR DESCRIPTION
Currently all whitespace is kept while parsing. This is potentially problematic, for example in RST or MarkDown output, where whitespace can have semantic (for example indentation, double newlines), and whitespace can result in invalid output (say when processing `"B(a\nb)"` and converting to RST, you get a newline inside a role argument that shouldn't be there).

As a first step to get rid of these problems, allow to configure how to handle whitespace during parsing. The default is as now (ignore). You can now strip whitespace, or keep newlines (so that line-breaks are kept when converting to RST or MarkDown markup, for example).

I also added code to strip some whitespace (spaces and tabs) around `HORIZONTALLINE`. These result in whitespace in resulting MarkDown or RST markup that shouldn't be there, and there is no reason to keep these at all.