### PR TITLE
Add Python 3.13 to CI and supported Python versions

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -29,19 +29,19 @@ jobs:
       matrix:
         include:
           - session: test
-            python-versions: "3.7, 3.8, 3.9, 3.10, 3.11, 3.12"
-            other-args: "-p 3.7 3.8 3.9 3.10 3.11 3.12"
+            python-versions: "3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
+            other-args: "-p 3.7 3.8 3.9 3.10 3.11 3.12 3.13"
             codecov: true
             packages: ""
 
           - session: lint
-            python-versions: "3.12"
+            python-versions: "3.13"
             other-args: ""
             codecov: false
             packages: ""
 
           - session: create_vectors
-            python-versions: "3.12"
+            python-versions: "3.13"
             other-args: ""
             codecov: false
             packages: ""

--- a/changelogs/fragments/python-3.13.yml
+++ b/changelogs/fragments/python-3.13.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Declare support for Python 3.13 (https://github.com/ansible-community/antsibull-docs-parser/pull/59).

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,12 +33,12 @@ def install(session: nox.Session, *args, editable=False, **kwargs):
     session.install(*args, "-U", **kwargs)
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session: nox.Session):
     install(session, ".[test, coverage]", editable=True)
     covfile = Path(session.create_tmp(), ".coverage")
     more_args = []
-    if session.python in ("3.11", "3.12"):
+    if session.python in {"3.11", "3.12", "3.13"}:
         more_args.append("--error-for-skips")
     session.run(
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 


### PR DESCRIPTION
Since Python 3.13.0 has been released, let's use it in CI and officially support it.