### PR TITLE
Drop support for Python < 3.9, modernize code

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -29,8 +29,8 @@ jobs:
       matrix:
         include:
           - session: test
-            python-versions: "3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
-            other-args: "-p 3.8 3.9 3.10 3.11 3.12 3.13"
+            python-versions: "3.9, 3.10, 3.11, 3.12, 3.13"
+            other-args: ""
             codecov: true
             packages: ""
 
@@ -76,79 +76,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           name: "${{ matrix.session }}"
-          working-directory: antsibull-docs-parser
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  nox-test-37:
-    # python3.7 is not available on ubuntu-latest
-    runs-on: ubuntu-22.04
-    name: "Run nox test session (Python 3.7)"
-    defaults:
-      run:
-        working-directory: antsibull-docs-parser
-    steps:
-      - name: Check out antsibull-docs-parser
-        uses: actions/checkout@v4
-        with:
-          path: antsibull-docs-parser
-          persist-credentials: false
-      - name: Setup nox
-        uses: wntrblm/nox@2025.02.09
-        with:
-          python-versions: "3.7"
-      - name: Set up nox environments
-        run: |
-          nox -v -e "test" -p 3.7 --install-only
-          nox -v -e coverage --install-only
-      - name: "Run nox -e test -p 3.7"
-        run: |
-          nox -v -e "test" -p 3.7 --reuse-existing-virtualenvs --no-install
-      - name: Report coverage
-        run: |
-          nox -v -e coverage --reuse-existing-virtualenvs --no-install
-      - name: Upload coverage
-        uses: codecov/codecov-action@v5
-        with:
-          name: "test"
-          working-directory: antsibull-docs-parser
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  nox-test-36:
-    # python3.6 is not available on ubuntu-latest
-    runs-on: ubuntu-20.04
-    name: "Run nox test session (Python 3.6)"
-    defaults:
-      run:
-        working-directory: antsibull-docs-parser
-    steps:
-      - name: Check out antsibull-docs-parser
-        uses: actions/checkout@v4
-        with:
-          path: antsibull-docs-parser
-          persist-credentials: false
-      - name: Setup nox
-        uses: wntrblm/nox@2024.03.02  # DO NOT UPDATE THIS! Newer versions do not work with Python 3.6
-        with:
-          python-versions: "3.6"
-      # https://github.com/ansible-community/antsibull-docs-parser/issues/25
-      # Newer virtualenv versions seem to cause failures with Python 3.6
-      - name: Setup nox - downgrade virtualenv
-        run: |
-          pipx inject --force nox 'virtualenv<20.22.0'
-      - name: Set up nox environments
-        run: |
-          nox -v -e test -p 3.6 --install-only
-          nox -v -e coverage --install-only
-      - name: Run unit tests
-        run: |
-          nox -v -e test -p 3.6 --reuse-existing-virtualenvs --no-install
-      - name: Report coverage
-        run: |
-          nox -v -e coverage --reuse-existing-virtualenvs --no-install
-      - name: Upload coverage
-        uses: codecov/codecov-action@v5
-        with:
-          name: nox-test-36
           working-directory: antsibull-docs-parser
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/changelogs/fragments/68-python.yml
+++ b/changelogs/fragments/68-python.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - "antsibull-docs-parser no longer supports Python 3.6, 3.7, and 3.8. Python 3.9+ is now required (https://github.com/ansible-community/antsibull-docs-parser/pull/68)."

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def install(session: nox.Session, *args, editable=False, **kwargs):
     session.install(*args, "-U", **kwargs)
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def test(session: nox.Session):
     install(session, ".[test, coverage]", editable=True)
     covfile = Path(session.create_tmp(), ".coverage")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ maintainers = [
   { name = "Maxwell G", email = "maxwell@gtmx.me" },
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Framework :: Ansible",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "antsibull-docs-parser"
 dynamic = ["version"]
 description = "Python library for processing Ansible documentation markup"
 readme = "README.md"
-requires-python = ">=3.6.1"
+requires-python = ">=3.9"
 license = "GPL-3.0-or-later AND BSD-2-Clause"
 license-files.globs = ["LICENSES/*.txt"]
 authors = [
@@ -26,9 +26,6 @@ classifiers = [
     "Framework :: Ansible",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/src/antsibull_docs_parser/__init__.py
+++ b/src/antsibull_docs_parser/__init__.py
@@ -7,6 +7,8 @@
 Library for processing Ansible documentation markup.
 """
 
+from __future__ import annotations
+
 __version__ = "1.1.1.post0"
 
 __all__ = ("__version__",)

--- a/src/antsibull_docs_parser/_parser_impl.py
+++ b/src/antsibull_docs_parser/_parser_impl.py
@@ -7,8 +7,9 @@
 Internal parsing code.
 """
 
+from __future__ import annotations
+
 import re
-import typing as t
 
 _ESCAPE_OR_COMMA = re.compile(r"\\(.)| *(,) *")
 _ESCAPE_OR_CLOSING = re.compile(r"\\(.)|([)])")
@@ -19,12 +20,12 @@ def parse_parameters_escaped(
     index: int,
     parameter_count: int,
     strict: bool,
-) -> t.Tuple[t.List[str], int, t.Optional[str]]:
-    result: t.List[str] = []
+) -> tuple[list[str], int, str | None]:
+    result: list[str] = []
     parameters_left = parameter_count
     while parameters_left > 1:
         parameters_left -= 1
-        value: t.List[str] = []
+        value: list[str] = []
         while True:
             match = _ESCAPE_OR_COMMA.search(text, pos=index)
             if not match:
@@ -77,8 +78,8 @@ def parse_parameters_unescaped(
     index: int,
     parameter_count: int,
     strict: bool,  # pylint: disable=unused-argument
-) -> t.Tuple[t.List[str], int, t.Optional[str]]:
-    result: t.List[str] = []
+) -> tuple[list[str], int, str | None]:
+    result: list[str] = []
     first = True
     parameters_left = parameter_count
     while parameters_left > 1:

--- a/src/antsibull_docs_parser/ansible_doc_text.py
+++ b/src/antsibull_docs_parser/ansible_doc_text.py
@@ -7,6 +7,8 @@
 Ansible-doc text serialization.
 """
 
+from __future__ import annotations
+
 import typing as t
 
 from . import dom
@@ -17,7 +19,7 @@ from .format import format_paragraphs as _format_paragraphs
 class AnsibleDocTextFormatter(Formatter):
     @staticmethod
     def _format_option_like(
-        part: t.Union[dom.OptionNamePart, dom.ReturnValuePart],
+        part: dom.OptionNamePart | dom.ReturnValuePart,
     ) -> str:
         value = part.value
         if value is None:
@@ -54,7 +56,7 @@ class AnsibleDocTextFormatter(Formatter):
     def format_link(self, part: dom.LinkPart) -> str:
         return f"{part.text} <{part.url}>"
 
-    def format_module(self, part: dom.ModulePart, url: t.Optional[str]) -> str:
+    def format_module(self, part: dom.ModulePart, url: str | None) -> str:
         return f"[{part.fqcn}]"
 
     def format_rst_ref(self, part: dom.RSTRefPart) -> str:
@@ -69,18 +71,16 @@ class AnsibleDocTextFormatter(Formatter):
     def format_env_variable(self, part: dom.EnvVariablePart) -> str:
         return f"`{part.name}'"
 
-    def format_option_name(self, part: dom.OptionNamePart, url: t.Optional[str]) -> str:
+    def format_option_name(self, part: dom.OptionNamePart, url: str | None) -> str:
         return self._format_option_like(part)
 
     def format_option_value(self, part: dom.OptionValuePart) -> str:
         return f"`{part.value}'"
 
-    def format_plugin(self, part: dom.PluginPart, url: t.Optional[str]) -> str:
+    def format_plugin(self, part: dom.PluginPart, url: str | None) -> str:
         return f"[{part.plugin.fqcn}]"
 
-    def format_return_value(
-        self, part: dom.ReturnValuePart, url: t.Optional[str]
-    ) -> str:
+    def format_return_value(self, part: dom.ReturnValuePart, url: str | None) -> str:
         return self._format_option_like(part)
 
 
@@ -90,12 +90,12 @@ DEFAULT_ANSIBLE_DOC_FORMATTER = AnsibleDocTextFormatter()
 def to_ansible_doc_text(
     paragraphs: t.Sequence[dom.Paragraph],
     formatter: Formatter = DEFAULT_ANSIBLE_DOC_FORMATTER,
-    link_provider: t.Optional[LinkProvider] = None,
+    link_provider: LinkProvider | None = None,
     par_start: str = "",
     par_end: str = "",
     par_sep: str = "\n\n",
     par_empty: str = "",
-    current_plugin: t.Optional[dom.PluginIdentifier] = None,
+    current_plugin: dom.PluginIdentifier | None = None,
 ) -> str:
     return _format_paragraphs(
         paragraphs,

--- a/src/antsibull_docs_parser/dom.py
+++ b/src/antsibull_docs_parser/dom.py
@@ -7,19 +7,14 @@
 DOM classes used by parser.
 """
 
+from __future__ import annotations
+
 import abc
-import sys
 import typing as t
 from enum import Enum
 from typing import NamedTuple
 
-if sys.version_info >= (3, 8):
-    ErrorType = t.Union[
-        t.Literal["ignore"], t.Literal["message"], t.Literal["exception"]
-    ]
-else:
-    # Python 3.6/3.7 do not have t.Literal
-    ErrorType = str  # pragma: no cover
+ErrorType = t.Union[t.Literal["ignore"], t.Literal["message"], t.Literal["exception"]]
 
 
 class PluginIdentifier(NamedTuple):
@@ -47,101 +42,101 @@ class PartType(Enum):
 
 class TextPart(NamedTuple):
     text: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.TEXT]" = PartType.TEXT
+    source: str | None = None
+    type: t.Literal[PartType.TEXT] = PartType.TEXT
 
 
 class ItalicPart(NamedTuple):
     text: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.ITALIC]" = PartType.ITALIC
+    source: str | None = None
+    type: t.Literal[PartType.ITALIC] = PartType.ITALIC
 
 
 class BoldPart(NamedTuple):
     text: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.BOLD]" = PartType.BOLD
+    source: str | None = None
+    type: t.Literal[PartType.BOLD] = PartType.BOLD
 
 
 class ModulePart(NamedTuple):
     fqcn: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.MODULE]" = PartType.MODULE
+    source: str | None = None
+    type: t.Literal[PartType.MODULE] = PartType.MODULE
 
 
 class PluginPart(NamedTuple):
     plugin: PluginIdentifier
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.PLUGIN]" = PartType.PLUGIN
+    source: str | None = None
+    type: t.Literal[PartType.PLUGIN] = PartType.PLUGIN
 
 
 class URLPart(NamedTuple):
     url: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.URL]" = PartType.URL
+    source: str | None = None
+    type: t.Literal[PartType.URL] = PartType.URL
 
 
 class LinkPart(NamedTuple):
     text: str
     url: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.LINK]" = PartType.LINK
+    source: str | None = None
+    type: t.Literal[PartType.LINK] = PartType.LINK
 
 
 class RSTRefPart(NamedTuple):
     text: str
     ref: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.RST_REF]" = PartType.RST_REF
+    source: str | None = None
+    type: t.Literal[PartType.RST_REF] = PartType.RST_REF
 
 
 class CodePart(NamedTuple):
     text: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.CODE]" = PartType.CODE
+    source: str | None = None
+    type: t.Literal[PartType.CODE] = PartType.CODE
 
 
 class OptionNamePart(NamedTuple):
-    plugin: t.Optional[PluginIdentifier]
-    entrypoint: t.Optional[str]  # present iff plugin.type == 'role'
-    link: t.List[str]
+    plugin: PluginIdentifier | None
+    entrypoint: str | None  # present iff plugin.type == 'role'
+    link: list[str]
     name: str
-    value: t.Optional[str]
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.OPTION_NAME]" = PartType.OPTION_NAME
+    value: str | None
+    source: str | None = None
+    type: t.Literal[PartType.OPTION_NAME] = PartType.OPTION_NAME
 
 
 class OptionValuePart(NamedTuple):
     value: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.OPTION_VALUE]" = PartType.OPTION_VALUE
+    source: str | None = None
+    type: t.Literal[PartType.OPTION_VALUE] = PartType.OPTION_VALUE
 
 
 class EnvVariablePart(NamedTuple):
     name: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.ENV_VARIABLE]" = PartType.ENV_VARIABLE
+    source: str | None = None
+    type: t.Literal[PartType.ENV_VARIABLE] = PartType.ENV_VARIABLE
 
 
 class ReturnValuePart(NamedTuple):
-    plugin: t.Optional[PluginIdentifier]
-    entrypoint: t.Optional[str]  # present iff plugin.type == 'role'
-    link: t.List[str]
+    plugin: PluginIdentifier | None
+    entrypoint: str | None  # present iff plugin.type == 'role'
+    link: list[str]
     name: str
-    value: t.Optional[str]
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.RETURN_VALUE]" = PartType.RETURN_VALUE
+    value: str | None
+    source: str | None = None
+    type: t.Literal[PartType.RETURN_VALUE] = PartType.RETURN_VALUE
 
 
 class HorizontalLinePart(NamedTuple):
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.HORIZONTAL_LINE]" = PartType.HORIZONTAL_LINE
+    source: str | None = None
+    type: t.Literal[PartType.HORIZONTAL_LINE] = PartType.HORIZONTAL_LINE
 
 
 class ErrorPart(NamedTuple):
     message: str
-    source: t.Optional[str] = None
-    type: "t.Literal[PartType.ERROR]" = PartType.ERROR
+    source: str | None = None
+    type: t.Literal[PartType.ERROR] = PartType.ERROR
 
 
 AnyPart = t.Union[
@@ -163,7 +158,7 @@ AnyPart = t.Union[
 ]
 
 
-Paragraph = t.List[AnyPart]
+Paragraph = list[AnyPart]
 
 
 class Walker(abc.ABC):

--- a/src/antsibull_docs_parser/format.py
+++ b/src/antsibull_docs_parser/format.py
@@ -7,6 +7,8 @@
 Flexible formatting of DOM.
 """
 
+from __future__ import annotations
+
 import abc
 import typing as t
 
@@ -21,21 +23,21 @@ class LinkProvider(abc.ABC):
     def plugin_link(  # pylint:disable=no-self-use
         self,
         plugin: dom.PluginIdentifier,  # pylint:disable=unused-argument
-    ) -> t.Optional[str]:
+    ) -> str | None:
         """Provides a link to a plugin."""
         return None
 
     def plugin_option_like_link(  # pylint:disable=no-self-use
         self,
         plugin: dom.PluginIdentifier,  # pylint:disable=unused-argument
-        entrypoint: t.Optional[str],  # pylint:disable=unused-argument
+        entrypoint: str | None,  # pylint:disable=unused-argument
         # pylint:disable-next=unused-argument
-        what: "t.Union[t.Literal['option'], t.Literal['retval']]",
+        what: t.Literal["option"] | t.Literal["retval"],
         # pylint:disable-next=unused-argument
-        name: t.List[str],
+        name: list[str],
         # pylint:disable-next=unused-argument
         current_plugin: bool,
-    ) -> t.Optional[str]:
+    ) -> str | None:
         """Provides a link to a plugin's option or return value."""
         return None
 
@@ -75,7 +77,7 @@ class Formatter(abc.ABC):
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def format_module(self, part: dom.ModulePart, url: t.Optional[str]) -> str:
+    def format_module(self, part: dom.ModulePart, url: str | None) -> str:
         pass  # pragma: no cover
 
     @abc.abstractmethod
@@ -95,7 +97,7 @@ class Formatter(abc.ABC):
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def format_option_name(self, part: dom.OptionNamePart, url: t.Optional[str]) -> str:
+    def format_option_name(self, part: dom.OptionNamePart, url: str | None) -> str:
         pass  # pragma: no cover
 
     @abc.abstractmethod
@@ -103,13 +105,11 @@ class Formatter(abc.ABC):
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def format_plugin(self, part: dom.PluginPart, url: t.Optional[str]) -> str:
+    def format_plugin(self, part: dom.PluginPart, url: str | None) -> str:
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def format_return_value(
-        self, part: dom.ReturnValuePart, url: t.Optional[str]
-    ) -> str:
+    def format_return_value(self, part: dom.ReturnValuePart, url: str | None) -> str:
         pass  # pragma: no cover
 
 
@@ -118,17 +118,17 @@ class _FormatWalker(dom.Walker):
     Walker which calls a formatter's functions and stores the result in a list.
     """
 
-    destination: t.List[str]
+    destination: list[str]
     formatter: Formatter
     link_provider: LinkProvider
-    current_plugin: t.Optional[dom.PluginIdentifier]
+    current_plugin: dom.PluginIdentifier | None
 
     def __init__(
         self,
-        destination: t.List[str],
+        destination: list[str],
         formatter: Formatter,
         link_provider: LinkProvider,
-        current_plugin: t.Optional[dom.PluginIdentifier],
+        current_plugin: dom.PluginIdentifier | None,
     ):
         self.destination = destination
         self.formatter = formatter
@@ -206,14 +206,14 @@ class _FormatWalker(dom.Walker):
 def format_paragraphs(
     paragraphs: t.Sequence[dom.Paragraph],
     formatter: Formatter,
-    link_provider: t.Optional[LinkProvider] = None,
+    link_provider: LinkProvider | None = None,
     par_start: str = "",
     par_end: str = "",
     par_sep: str = "",
     par_empty: str = "",
-    current_plugin: t.Optional[dom.PluginIdentifier] = None,
+    current_plugin: dom.PluginIdentifier | None = None,
     *,
-    postprocess_paragraph: t.Optional[t.Callable[[str], str]] = None,
+    postprocess_paragraph: t.Callable[[str], str] | None = None,
 ) -> str:
     """
     Apply the formatter to all parts of the given paragraphs, concatenate the results,
@@ -224,13 +224,13 @@ def format_paragraphs(
     """
     if link_provider is None:
         link_provider = _DefaultLinkProvider()
-    result: t.List[str] = []
+    result: list[str] = []
     for paragraph in paragraphs:
         if result:
             result.append(par_sep)
         result.append(par_start)
 
-        par_result: t.List[str] = []
+        par_result: list[str] = []
         walker = _FormatWalker(par_result, formatter, link_provider, current_plugin)
         dom.walk(paragraph, walker)
         par = "".join(par_result)

--- a/src/antsibull_docs_parser/html.py
+++ b/src/antsibull_docs_parser/html.py
@@ -7,6 +7,8 @@
 HTML serialization.
 """
 
+from __future__ import annotations
+
 import typing as t
 from html import escape as _html_escape
 from urllib.parse import quote
@@ -29,7 +31,7 @@ def _url_escape(url: str) -> str:
 class AntsibullHTMLFormatter(Formatter):
     @staticmethod
     def _format_option_like(
-        part: t.Union[dom.OptionNamePart, dom.ReturnValuePart], url: t.Optional[str]
+        part: dom.OptionNamePart | dom.ReturnValuePart, url: str | None
     ) -> str:
         link_start = ""
         link_end = ""
@@ -77,7 +79,7 @@ class AntsibullHTMLFormatter(Formatter):
     def format_link(self, part: dom.LinkPart) -> str:
         return f"<a href='{_html_escape(_url_escape(part.url))}'>{html_escape(part.text)}</a>"
 
-    def format_module(self, part: dom.ModulePart, url: t.Optional[str]) -> str:
+    def format_module(self, part: dom.ModulePart, url: str | None) -> str:
         if not url:
             return f"<span class='module'>{html_escape(part.fqcn)}</span>"
         return (
@@ -103,13 +105,13 @@ class AntsibullHTMLFormatter(Formatter):
             f"{html_escape(part.name)}</code>"
         )
 
-    def format_option_name(self, part: dom.OptionNamePart, url: t.Optional[str]) -> str:
+    def format_option_name(self, part: dom.OptionNamePart, url: str | None) -> str:
         return self._format_option_like(part, url)
 
     def format_option_value(self, part: dom.OptionValuePart) -> str:
         return f'<code class="ansible-value literal notranslate">{html_escape(part.value)}</code>'
 
-    def format_plugin(self, part: dom.PluginPart, url: t.Optional[str]) -> str:
+    def format_plugin(self, part: dom.PluginPart, url: str | None) -> str:
         if not url:
             return f"<span class='module'>{html_escape(part.plugin.fqcn)}</span>"
         return (
@@ -117,16 +119,14 @@ class AntsibullHTMLFormatter(Formatter):
             f"{html_escape(part.plugin.fqcn)}</a>"
         )
 
-    def format_return_value(
-        self, part: dom.ReturnValuePart, url: t.Optional[str]
-    ) -> str:
+    def format_return_value(self, part: dom.ReturnValuePart, url: str | None) -> str:
         return self._format_option_like(part, url)
 
 
 class PlainHTMLFormatter(Formatter):
     @staticmethod
     def _format_option_like(
-        part: t.Union[dom.OptionNamePart, dom.ReturnValuePart], url: t.Optional[str]
+        part: dom.OptionNamePart | dom.ReturnValuePart, url: str | None
     ) -> str:
         link_start = ""
         link_end = ""
@@ -162,7 +162,7 @@ class PlainHTMLFormatter(Formatter):
     def format_link(self, part: dom.LinkPart) -> str:
         return f"<a href='{_html_escape(_url_escape(part.url))}'>{html_escape(part.text)}</a>"
 
-    def format_module(self, part: dom.ModulePart, url: t.Optional[str]) -> str:
+    def format_module(self, part: dom.ModulePart, url: str | None) -> str:
         if not url:
             return f"<span>{html_escape(part.fqcn)}</span>"
         return (
@@ -184,20 +184,18 @@ class PlainHTMLFormatter(Formatter):
     def format_env_variable(self, part: dom.EnvVariablePart) -> str:
         return f"<code>{html_escape(part.name)}</code>"
 
-    def format_option_name(self, part: dom.OptionNamePart, url: t.Optional[str]) -> str:
+    def format_option_name(self, part: dom.OptionNamePart, url: str | None) -> str:
         return self._format_option_like(part, url)
 
     def format_option_value(self, part: dom.OptionValuePart) -> str:
         return f"<code>{html_escape(part.value)}</code>"
 
-    def format_plugin(self, part: dom.PluginPart, url: t.Optional[str]) -> str:
+    def format_plugin(self, part: dom.PluginPart, url: str | None) -> str:
         if not url:
             return f"<span>{html_escape(part.plugin.fqcn)}</span>"
         return f"<a href='{_html_escape(_url_escape(url))}'>{html_escape(part.plugin.fqcn)}</a>"
 
-    def format_return_value(
-        self, part: dom.ReturnValuePart, url: t.Optional[str]
-    ) -> str:
+    def format_return_value(self, part: dom.ReturnValuePart, url: str | None) -> str:
         return self._format_option_like(part, url)
 
 
@@ -208,12 +206,12 @@ DEFAULT_PLAIN_FORMATTER = PlainHTMLFormatter()
 def to_html(
     paragraphs: t.Sequence[dom.Paragraph],
     formatter: Formatter = DEFAULT_ANTSIBULL_FORMATTER,
-    link_provider: t.Optional[LinkProvider] = None,
+    link_provider: LinkProvider | None = None,
     par_start: str = "<p>",
     par_end: str = "</p>",
     par_sep: str = "",
     par_empty: str = "",
-    current_plugin: t.Optional[dom.PluginIdentifier] = None,
+    current_plugin: dom.PluginIdentifier | None = None,
 ) -> str:
     return _format_paragraphs(
         paragraphs,
@@ -230,12 +228,12 @@ def to_html(
 def to_html_plain(
     paragraphs: t.Sequence[dom.Paragraph],
     formatter: Formatter = DEFAULT_PLAIN_FORMATTER,
-    link_provider: t.Optional[LinkProvider] = None,
+    link_provider: LinkProvider | None = None,
     par_start: str = "<p>",
     par_end: str = "</p>",
     par_sep: str = "",
     par_empty: str = "",
-    current_plugin: t.Optional[dom.PluginIdentifier] = None,
+    current_plugin: dom.PluginIdentifier | None = None,
 ) -> str:
     return _format_paragraphs(
         paragraphs,

--- a/src/antsibull_docs_parser/md.py
+++ b/src/antsibull_docs_parser/md.py
@@ -7,6 +7,8 @@
 MarkDown serialization.
 """
 
+from __future__ import annotations
+
 import re
 import typing as t
 
@@ -26,7 +28,7 @@ def md_escape(text: str) -> str:
 class MDFormatter(Formatter):
     @staticmethod
     def _format_option_like(
-        part: t.Union[dom.OptionNamePart, dom.ReturnValuePart], url: t.Optional[str]
+        part: dom.OptionNamePart | dom.ReturnValuePart, url: str | None
     ) -> str:
         link_start = ""
         link_end = ""
@@ -63,7 +65,7 @@ class MDFormatter(Formatter):
         url_escaped = md_escape(_url_escape(part.url))
         return f"[{md_escape(part.text)}]({url_escaped})"
 
-    def format_module(self, part: dom.ModulePart, url: t.Optional[str]) -> str:
+    def format_module(self, part: dom.ModulePart, url: str | None) -> str:
         if url:
             return f"[{md_escape(part.fqcn)}]({md_escape(_url_escape(url))})"
         return md_escape(part.fqcn)
@@ -81,20 +83,18 @@ class MDFormatter(Formatter):
     def format_env_variable(self, part: dom.EnvVariablePart) -> str:
         return f"<code>{md_escape(part.name)}</code>"
 
-    def format_option_name(self, part: dom.OptionNamePart, url: t.Optional[str]) -> str:
+    def format_option_name(self, part: dom.OptionNamePart, url: str | None) -> str:
         return self._format_option_like(part, url)
 
     def format_option_value(self, part: dom.OptionValuePart) -> str:
         return f"<code>{md_escape(part.value)}</code>"
 
-    def format_plugin(self, part: dom.PluginPart, url: t.Optional[str]) -> str:
+    def format_plugin(self, part: dom.PluginPart, url: str | None) -> str:
         if url:
             return f"[{md_escape(part.plugin.fqcn)}]({md_escape(_url_escape(url))})"
         return md_escape(part.plugin.fqcn)
 
-    def format_return_value(
-        self, part: dom.ReturnValuePart, url: t.Optional[str]
-    ) -> str:
+    def format_return_value(self, part: dom.ReturnValuePart, url: str | None) -> str:
         return self._format_option_like(part, url)
 
 
@@ -111,12 +111,12 @@ def postprocess_md_paragraph(par: str) -> str:
 def to_md(
     paragraphs: t.Sequence[dom.Paragraph],
     formatter: Formatter = DEFAULT_FORMATTER,
-    link_provider: t.Optional[LinkProvider] = None,
+    link_provider: LinkProvider | None = None,
     par_start: str = "",
     par_end: str = "",
     par_sep: str = "\n\n",
     par_empty: str = " ",
-    current_plugin: t.Optional[dom.PluginIdentifier] = None,
+    current_plugin: dom.PluginIdentifier | None = None,
 ) -> str:
     return _format_paragraphs(
         paragraphs,

--- a/src/antsibull_docs_parser/parser.py
+++ b/src/antsibull_docs_parser/parser.py
@@ -7,6 +7,8 @@
 Parser for formatted texts.
 """
 
+from __future__ import annotations
+
 import abc
 import re
 import typing as t
@@ -59,7 +61,7 @@ class Whitespace(_Enum):
 
 
 def _add_whitespace(
-    result: t.List[str],
+    result: list[str],
     ws: str,
     *,
     whitespace: Whitespace,
@@ -124,8 +126,8 @@ def _process_whitespace(
 
 
 class Context(t.NamedTuple):
-    current_plugin: t.Optional[dom.PluginIdentifier] = None
-    role_entrypoint: t.Optional[str] = None
+    current_plugin: dom.PluginIdentifier | None = None
+    role_entrypoint: str | None = None
 
 
 class CommandParser(abc.ABC):
@@ -150,9 +152,9 @@ class CommandParser(abc.ABC):
     @abc.abstractmethod
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         pass  # pragma: no cover
@@ -188,9 +190,9 @@ class _Italics(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         return dom.ItalicPart(
@@ -207,9 +209,9 @@ class _Bold(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         return dom.BoldPart(
@@ -226,9 +228,9 @@ class _Module(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         fqcn = _process_whitespace(
@@ -245,9 +247,9 @@ class _URL(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         return dom.URLPart(
@@ -264,9 +266,9 @@ class _Link(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         text = _process_whitespace(
@@ -284,9 +286,9 @@ class _RSTRef(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         text = _process_whitespace(
@@ -304,9 +306,9 @@ class _Code(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         return dom.CodePart(
@@ -328,9 +330,9 @@ class _HorizontalLine(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         return dom.HorizontalLinePart(source=source)
@@ -342,17 +344,17 @@ class _HorizontalLine(CommandParserEx):
 def _parse_option_like(
     text: str,
     context: Context,
-) -> t.Tuple[
-    t.Optional[dom.PluginIdentifier],
-    t.Optional[str],
-    t.List[str],
+) -> tuple[
+    dom.PluginIdentifier | None,
+    str | None,
+    list[str],
     str,
-    t.Optional[str],
+    str | None,
 ]:
     value = None
     if "=" in text:
         text, value = text.split("=", 1)
-    entrypoint: t.Optional[str] = None
+    entrypoint: str | None = None
     m = _FQCN_TYPE_PREFIX_RE.match(text)
     if m:
         plugin_fqcn = m.group(1)
@@ -393,9 +395,9 @@ class _Plugin(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         name = _process_whitespace(
@@ -419,9 +421,9 @@ class _EnvVar(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         return dom.EnvVariablePart(
@@ -441,9 +443,9 @@ class _OptionValue(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         return dom.OptionValuePart(
@@ -463,9 +465,9 @@ class _OptionName(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         plugin, entrypoint, link, name, value = _parse_option_like(
@@ -493,9 +495,9 @@ class _ReturnValue(CommandParserEx):
 
     def parse(
         self,
-        parameters: t.List[str],
+        parameters: list[str],
         context: Context,
-        source: t.Optional[str],
+        source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
         plugin, entrypoint, link, name, value = _parse_option_like(
@@ -574,8 +576,8 @@ class Parser:
         whitespace: Whitespace,
         offset: int,
     ) -> int:
-        args: t.List[str]
-        error: t.Optional[str] = None
+        args: list[str]
+        error: str | None = None
         if cmd.parameters == 0:
             args = []
         elif cmd.escaped_arguments:
@@ -673,7 +675,7 @@ _SEMANTIC_MARKUP = Parser(_COMMANDS)
 
 
 def parse(
-    text: t.Union[str, t.Sequence[str]],
+    text: str | t.Sequence[str],
     context: Context,
     errors: dom.ErrorType = "message",
     only_classic_markup: bool = False,
@@ -682,7 +684,7 @@ def parse(
     helpful_errors: bool = True,
     *,
     whitespace: Whitespace = Whitespace.IGNORE,
-) -> t.List[dom.Paragraph]:
+) -> list[dom.Paragraph]:
     """
     Parse a string, or a sequence of strings, to a list of paragraphs.
 

--- a/src/antsibull_docs_parser/parser.py
+++ b/src/antsibull_docs_parser/parser.py
@@ -546,7 +546,7 @@ def _command_re(command: CommandParser) -> str:
 
 class Parser:
     _group_map: t.Mapping[str, CommandParser]
-    _re: "re.Pattern"  # on Python 3.6 the type is called differently
+    _re: re.Pattern
 
     def __init__(self, commands: t.Sequence[CommandParser]):
         self._group_map = {

--- a/src/antsibull_docs_parser/rst.py
+++ b/src/antsibull_docs_parser/rst.py
@@ -7,6 +7,8 @@
 ReStructured Text serialization.
 """
 
+from __future__ import annotations
+
 import re
 import typing as t
 
@@ -49,9 +51,9 @@ def rst_escape(
 class AntsibullRSTFormatter(Formatter):
     @staticmethod
     def _format_option_like(
-        part: t.Union[dom.OptionNamePart, dom.ReturnValuePart], role: str
+        part: dom.OptionNamePart | dom.ReturnValuePart, role: str
     ) -> str:
-        result: t.List[str] = []
+        result: list[str] = []
         plugin = part.plugin
         if plugin:
             result.append(plugin.fqcn)
@@ -107,7 +109,7 @@ class AntsibullRSTFormatter(Formatter):
         text = rst_escape(part.text, escape_ending_whitespace=True)
         return f"\\ `{text} <{_url_escape(part.url)}>`__\\ "
 
-    def format_module(self, part: dom.ModulePart, url: t.Optional[str]) -> str:
+    def format_module(self, part: dom.ModulePart, url: str | None) -> str:
         text = rst_escape(
             part.fqcn, escape_ending_whitespace=True, must_not_be_empty=True
         )
@@ -134,7 +136,7 @@ class AntsibullRSTFormatter(Formatter):
         )
         return f"\\ :envvar:`{text}`\\ "
 
-    def format_option_name(self, part: dom.OptionNamePart, url: t.Optional[str]) -> str:
+    def format_option_name(self, part: dom.OptionNamePart, url: str | None) -> str:
         return self._format_option_like(part, "ansopt")
 
     def format_option_value(self, part: dom.OptionValuePart) -> str:
@@ -143,24 +145,22 @@ class AntsibullRSTFormatter(Formatter):
         )
         return f"\\ :ansval:`{text}`\\ "
 
-    def format_plugin(self, part: dom.PluginPart, url: t.Optional[str]) -> str:
+    def format_plugin(self, part: dom.PluginPart, url: str | None) -> str:
         return (
             f"\\ :ref:`{rst_escape(part.plugin.fqcn)} "
             f"<ansible_collections.{part.plugin.fqcn}_{part.plugin.type}>`\\ "
         )
 
-    def format_return_value(
-        self, part: dom.ReturnValuePart, url: t.Optional[str]
-    ) -> str:
+    def format_return_value(self, part: dom.ReturnValuePart, url: str | None) -> str:
         return self._format_option_like(part, "ansretval")
 
 
 class PlainRSTFormatter(Formatter):
     @staticmethod
     def _format_option_like(
-        part: t.Union[dom.OptionNamePart, dom.ReturnValuePart],
+        part: dom.OptionNamePart | dom.ReturnValuePart,
     ) -> str:
-        plugin_result: t.List[str] = []
+        plugin_result: list[str] = []
         plugin = part.plugin
         if plugin:
             plugin_result.append(plugin.type)
@@ -225,7 +225,7 @@ class PlainRSTFormatter(Formatter):
         text = rst_escape(part.text, escape_ending_whitespace=True)
         return f"\\ `{text} <{_url_escape(part.url)}>`__\\ "
 
-    def format_module(self, part: dom.ModulePart, url: t.Optional[str]) -> str:
+    def format_module(self, part: dom.ModulePart, url: str | None) -> str:
         text = rst_escape(
             part.fqcn, escape_ending_whitespace=True, must_not_be_empty=True
         )
@@ -252,7 +252,7 @@ class PlainRSTFormatter(Formatter):
         )
         return f"\\ :envvar:`{text}`\\ "
 
-    def format_option_name(self, part: dom.OptionNamePart, url: t.Optional[str]) -> str:
+    def format_option_name(self, part: dom.OptionNamePart, url: str | None) -> str:
         return self._format_option_like(part)
 
     def format_option_value(self, part: dom.OptionValuePart) -> str:
@@ -261,15 +261,13 @@ class PlainRSTFormatter(Formatter):
         )
         return f"\\ :literal:`{text}`\\ "
 
-    def format_plugin(self, part: dom.PluginPart, url: t.Optional[str]) -> str:
+    def format_plugin(self, part: dom.PluginPart, url: str | None) -> str:
         return (
             f"\\ :ref:`{rst_escape(part.plugin.fqcn)} "
             f"<ansible_collections.{part.plugin.fqcn}_{part.plugin.type}>`\\ "
         )
 
-    def format_return_value(
-        self, part: dom.ReturnValuePart, url: t.Optional[str]
-    ) -> str:
+    def format_return_value(self, part: dom.ReturnValuePart, url: str | None) -> str:
         return self._format_option_like(part)
 
 
@@ -330,13 +328,13 @@ def _remove_backslash_space(line: str) -> str:
     return line
 
 
-def _check_line(index: int, lines: t.List[str], line: str) -> bool:
+def _check_line(index: int, lines: list[str], line: str) -> bool:
     if index < 0 or index >= len(lines):
         return False
     return lines[index] == line
 
 
-def _modify_line(index: int, line: str, lines: t.List[str]) -> bool:
+def _modify_line(index: int, line: str, lines: list[str]) -> bool:
     raw_html = ".. raw:: html"
     dashes = "------------"
     hr = "  <hr>"
@@ -380,12 +378,12 @@ def postprocess_rst_paragraph(par: str) -> str:
 def to_rst(
     paragraphs: t.Sequence[dom.Paragraph],
     formatter: Formatter = DEFAULT_ANTSIBULL_FORMATTER,
-    link_provider: t.Optional[LinkProvider] = None,
+    link_provider: LinkProvider | None = None,
     par_start: str = "",
     par_end: str = "",
     par_sep: str = "\n\n",
     par_empty: str = "\\",
-    current_plugin: t.Optional[dom.PluginIdentifier] = None,
+    current_plugin: dom.PluginIdentifier | None = None,
 ) -> str:
     return _format_paragraphs(
         paragraphs,
@@ -403,12 +401,12 @@ def to_rst(
 def to_rst_plain(
     paragraphs: t.Sequence[dom.Paragraph],
     formatter: Formatter = DEFAULT_PLAIN_FORMATTER,
-    link_provider: t.Optional[LinkProvider] = None,
+    link_provider: LinkProvider | None = None,
     par_start: str = "",
     par_end: str = "",
     par_sep: str = "\n\n",
     par_empty: str = "\\",
-    current_plugin: t.Optional[dom.PluginIdentifier] = None,
+    current_plugin: dom.PluginIdentifier | None = None,
 ) -> str:
     return _format_paragraphs(
         paragraphs,


### PR DESCRIPTION
This also elegantly solves https://forum.ansible.com/t/40187. And since Python's package managers generally care about the minimum Python version specified by a package, this isn't a breaking change w.r.t. semver IMO.