### PR TITLE
Extend Ansible markup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,7 @@
 [flake8]
 extend-ignore = E203
 count = true
-max-complexity = 10
+max-complexity = 11
 # black's max-line-length is 89, but it doesn't touch long string literals.
 max-line-length = 100
 statistics = true

--- a/changelogs/fragments/72-extend-ansible-markup.yml
+++ b/changelogs/fragments/72-extend-ansible-markup.yml
@@ -1,2 +1,3 @@
 major_changes:
   - "Extend plugin reference ``P(...)`` to allow referencing a role's entrypoint (https://github.com/ansible-community/antsibull-docs-parser/pull/72)."
+  - "Extend environment variable ``E(...)`` to allow specifying a value (https://github.com/ansible-community/antsibull-docs-parser/pull/72)."

--- a/changelogs/fragments/72-extend-ansible-markup.yml
+++ b/changelogs/fragments/72-extend-ansible-markup.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - "Extend plugin reference ``P(...)`` to allow referencing a role's entrypoint (https://github.com/ansible-community/antsibull-docs-parser/pull/72)."

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -80,7 +80,9 @@ Renderers that can not link to RST labels should simply show the title instead.
 
 ### Environment variable references
 
-The `E(...)` markup's parameter is the name of an environment variable.
+The `E(...)` markup's parameter is the name of an environment variable, with an optional value.
+
+If the argument contains `=`, the part before the `=` is the environment variable's name, and the part after its value. If no `=` is present, the whole argument is the environment variable's name.
 
 ### Ansible values
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -70,7 +70,7 @@ The `U(...)` markup describes a single URL without a title. The `L(..., ...)` ma
 
 Module references `M(...)` use FQCNs (fully qualified collection names) to reference modules in collections. The collection name `ansible.builtin` is used for modules included with ansible-core.
 
-Plugin references `P(...)` must have a parameter of the form `fqcn#type`, where `fqcn` is the FQCN of the plugin, and `type` the plugin's type.
+Plugin references `P(...)` must have a parameter of the form `fqcn#type`, where `fqcn` is the FQCN of the plugin, and `type` the plugin's type. In case `type` is `role`, the form `fqcn#role:entrypoint` is allowed as well.
 
 ### ReStructuredText references
 

--- a/src/antsibull_docs_parser/dom.py
+++ b/src/antsibull_docs_parser/dom.py
@@ -120,7 +120,9 @@ class PluginPart(NamedTuple):
     plugin: PluginIdentifier
     """The plugin."""
 
-    entrypoint: str | None  # can be present if plugin.type == "role"
+    entrypoint: str | None = (
+        None  # can be present if plugin.type == "role"; default value for backwards compatibility
+    )
     """In case the plugin is a role, this can be an entrypoint of that role."""
 
     source: str | None = None
@@ -251,7 +253,7 @@ class EnvVariablePart(NamedTuple):
     name: str
     """The environment variable's name."""
 
-    value: str | None
+    value: str | None = None  # default value for backwards compatibility
     """The (optional) environment variable's value."""
 
     source: str | None = None

--- a/src/antsibull_docs_parser/dom.py
+++ b/src/antsibull_docs_parser/dom.py
@@ -251,6 +251,9 @@ class EnvVariablePart(NamedTuple):
     name: str
     """The environment variable's name."""
 
+    value: str | None
+    """The (optional) environment variable's value."""
+
     source: str | None = None
     """The (optional) source of the markup."""
 

--- a/src/antsibull_docs_parser/dom.py
+++ b/src/antsibull_docs_parser/dom.py
@@ -120,6 +120,9 @@ class PluginPart(NamedTuple):
     plugin: PluginIdentifier
     """The plugin."""
 
+    entrypoint: str | None  # can be present if plugin.type == "role"
+    """In case the plugin is a role, this can be an entrypoint of that role."""
+
     source: str | None = None
     """The (optional) source of the markup."""
 

--- a/src/antsibull_docs_parser/parser.py
+++ b/src/antsibull_docs_parser/parser.py
@@ -465,13 +465,17 @@ class _EnvVar(CommandParserEx):
         source: str | None,
         whitespace: Whitespace,
     ) -> dom.AnyPart:
+        name = _process_whitespace(
+            parameters[0],
+            whitespace=whitespace,
+            code_environment=True,
+            no_newlines=True,
+        )
+        name, sep, value_ = name.partition("=")
+        value = value_ if sep else None
         return dom.EnvVariablePart(
-            name=_process_whitespace(
-                parameters[0],
-                whitespace=whitespace,
-                code_environment=True,
-                no_newlines=True,
-            ),
+            name=name,
+            value=value,
             source=source,
         )
 

--- a/src/antsibull_docs_parser/parser.py
+++ b/src/antsibull_docs_parser/parser.py
@@ -21,6 +21,7 @@ _IGNORE_MARKER = "ignore:"
 _ARRAY_STUB_RE = re.compile(r"\[([^\]]*)\]")
 _FQCN_TYPE_PREFIX_RE = re.compile(r"^([^.]+\.[^.]+\.[^#]+)#([^:]+):(.*)$")
 _FQCN = re.compile(r"^[A-Za-z0-9_]+\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+$")
+_ENTRYPOINT = re.compile(r"^[A-Za-z0-9_]+$")
 _PLUGIN_TYPE = re.compile(r"^[a-z_]+$")
 _WHITESPACE = re.compile(r"([\s]+)")
 _DANGEROUS_WS = re.compile(r"[\t\n\r]")
@@ -31,6 +32,10 @@ _SPACES_TO_KEEP = re.compile(
 
 def _is_fqcn(text: str) -> bool:
     return _FQCN.match(text) is not None
+
+
+def _is_entrypoint(text: str) -> bool:
+    return _ENTRYPOINT.match(text) is not None
 
 
 def _is_plugin_type(text: str) -> bool:
@@ -397,6 +402,8 @@ def _parse_option_like(
         if sep:
             entrypoint = part1
             text = part2
+            if not _is_entrypoint(entrypoint):
+                raise ValueError(f"Entrypoint {_repr(entrypoint)} is not valid")
         if entrypoint is None:
             raise ValueError("Role reference is missing entrypoint")
     if ":" in text or "#" in text:
@@ -427,12 +434,23 @@ class _Plugin(CommandParserEx):
         if "#" not in name:
             raise ValueError(f"Parameter {_repr(name)} is not of the form FQCN#type")
         fqcn, ptype = name.split("#", 1)
+        entrypoint = None
+        part1, sep, part2 = ptype.partition(":")
+        if sep:
+            ptype = part1
+            entrypoint = part2
+            if not _is_entrypoint(entrypoint):
+                raise ValueError(f"Entrypoint {_repr(entrypoint)} is not valid")
         if not _is_fqcn(fqcn):
             raise ValueError(f"Plugin name {_repr(fqcn)} is not a FQCN")
         if not _is_plugin_type(ptype):
             raise ValueError(f"Plugin type {_repr(ptype)} is not valid")
+        if entrypoint is not None and ptype != "role":
+            raise ValueError("Only role references can have entrypoints")
         return dom.PluginPart(
-            plugin=dom.PluginIdentifier(fqcn=fqcn, type=ptype), source=source
+            plugin=dom.PluginIdentifier(fqcn=fqcn, type=ptype),
+            entrypoint=entrypoint,
+            source=source,
         )
 
 

--- a/tests/unit/test_dom.py
+++ b/tests/unit/test_dom.py
@@ -101,7 +101,7 @@ TEST_WALKER = [
     ],
     [
         dom.TextPart(text="foo "),
-        dom.EnvVariablePart(name="a),b"),
+        dom.EnvVariablePart(name="a),b", value=None),
         dom.TextPart(text=" "),
         dom.PluginPart(
             plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="bam"), entrypoint=None

--- a/tests/unit/test_dom.py
+++ b/tests/unit/test_dom.py
@@ -103,7 +103,9 @@ TEST_WALKER = [
         dom.TextPart(text="foo "),
         dom.EnvVariablePart(name="a),b"),
         dom.TextPart(text=" "),
-        dom.PluginPart(plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="bam")),
+        dom.PluginPart(
+            plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="bam"), entrypoint=None
+        ),
         dom.TextPart(text=" baz "),
         dom.OptionValuePart(value=" b,na)\\m, "),
         dom.TextPart(text=" "),

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -192,13 +192,15 @@ TEST_PARSE_DATA: t.List[
     ),
     # semantic markup:
     (
-        "foo E(a\\),b) P(foo.bar.baz#bam) baz V( b\\,\\na\\)\\\\m\\, ) O(foo) ",
+        "foo E(a\\),b) E(foo=bar=baz) P(foo.bar.baz#bam) baz V( b\\,\\na\\)\\\\m\\, ) O(foo) ",
         Context(),
         {},
         [
             [
                 dom.TextPart(text="foo "),
-                dom.EnvVariablePart(name="a),b"),
+                dom.EnvVariablePart(name="a),b", value=None),
+                dom.TextPart(text=" "),
+                dom.EnvVariablePart(name="foo", value="bar=baz"),
                 dom.TextPart(text=" "),
                 dom.PluginPart(
                     plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="bam"),
@@ -215,13 +217,17 @@ TEST_PARSE_DATA: t.List[
         ],
     ),
     (
-        "foo E(a\\),b) P(foo.bar.baz#bam) baz V( b\\,\\na\\)\\\\m\\, ) O(foo) ",
+        "foo E(a\\),b) E(foo=bar=baz) P(foo.bar.baz#bam) baz V( b\\,\\na\\)\\\\m\\, ) O(foo) ",
         Context(),
         dict(add_source=True),
         [
             [
                 dom.TextPart(text="foo ", source="foo "),
-                dom.EnvVariablePart(name="a),b", source="E(a\\),b)"),
+                dom.EnvVariablePart(name="a),b", value=None, source="E(a\\),b)"),
+                dom.TextPart(text=" ", source=" "),
+                dom.EnvVariablePart(
+                    name="foo", value="bar=baz", source="E(foo=bar=baz)"
+                ),
                 dom.TextPart(text=" ", source=" "),
                 dom.PluginPart(
                     plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="bam"),

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -201,7 +201,8 @@ TEST_PARSE_DATA: t.List[
                 dom.EnvVariablePart(name="a),b"),
                 dom.TextPart(text=" "),
                 dom.PluginPart(
-                    plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="bam")
+                    plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="bam"),
+                    entrypoint=None,
                 ),
                 dom.TextPart(text=" baz "),
                 dom.OptionValuePart(value=" b,na)\\m, "),
@@ -224,6 +225,7 @@ TEST_PARSE_DATA: t.List[
                 dom.TextPart(text=" ", source=" "),
                 dom.PluginPart(
                     plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="bam"),
+                    entrypoint=None,
                     source="P(foo.bar.baz#bam)",
                 ),
                 dom.TextPart(text=" baz ", source=" baz "),
@@ -240,6 +242,26 @@ TEST_PARSE_DATA: t.List[
                     source="O(foo)",
                 ),
                 dom.TextPart(text=" ", source=" "),
+            ],
+        ],
+    ),
+    (
+        "P(foo.bar.baz#role) P(foo.bar.baz#role:entrypoint)",
+        Context(),
+        dict(add_source=True),
+        [
+            [
+                dom.PluginPart(
+                    plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="role"),
+                    entrypoint=None,
+                    source="P(foo.bar.baz#role)",
+                ),
+                dom.TextPart(text=" ", source=" "),
+                dom.PluginPart(
+                    plugin=dom.PluginIdentifier(fqcn="foo.bar.baz", type="role"),
+                    entrypoint="entrypoint",
+                    source="P(foo.bar.baz#role:entrypoint)",
+                ),
             ],
         ],
     ),
@@ -843,6 +865,18 @@ TEST_PARSE_THROW_DATA: t.List[
         dict(errors="exception", helpful_errors=False),
         'While parsing P() at index 1: Plugin type "b m" is not valid',
     ),
+    (
+        "P(foo.bar.baz#module:e p)",
+        Context(),
+        dict(errors="exception", helpful_errors=False),
+        'While parsing P() at index 1: Entrypoint "e p" is not valid',
+    ),
+    (
+        "P(foo.bar.baz#module:entrypoint)",
+        Context(),
+        dict(errors="exception", helpful_errors=False),
+        "While parsing P() at index 1: Only role references can have entrypoints",
+    ),
     # bad option name/return value (throw error):
     (
         "O(f o.b r.b z#bam:foobar)",
@@ -867,6 +901,12 @@ TEST_PARSE_THROW_DATA: t.List[
         Context(),
         dict(errors="exception", helpful_errors=False),
         "While parsing O() at index 1: Role reference is missing entrypoint",
+    ),
+    (
+        "O(foo.bar.baz#role:e p:bam)",
+        Context(),
+        dict(errors="exception", helpful_errors=False),
+        'While parsing O() at index 1: Entrypoint "e p" is not valid',
     ),
 ]
 


### PR DESCRIPTION
I'd like to extend Ansible markup in two ways:

- [x] Allow `P(foo.bar.baz#role)` to also refer to an entrypoint. Suggested syntax: `P(foo.bar.baz#role:entrypoint)` (this is to how entrypoints work with `O(...)` and `RV(...)`).
- [x] Allow `E(FOO)` to also have a value. Suggested syntax: `E(FOO=bar)` (this is how values work with `O(...)` and `RV(...)`).
