### PR TITLE
Sign release tags and release commits

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -186,7 +186,9 @@ def bump(session: nox.Session):
             fragment_file,
             external=True,
         )
-        session.run("git", "commit", "-m", f"Prepare {version}.", external=True)
+        session.run(
+            "git", "commit", "-m", f"Prepare {version}.", "--gpg-sign", external=True
+        )
     session.run("antsibull-changelog", "release")
     session.run(
         "git",
@@ -201,7 +203,9 @@ def bump(session: nox.Session):
         external=True,
     )
     install(session, ".")  # Smoke test
-    session.run("git", "commit", "-m", f"Release {version}.", external=True)
+    session.run(
+        "git", "commit", "-m", f"Release {version}.", "--gpg-sign", external=True
+    )
     session.run(
         "git",
         "tag",
@@ -225,7 +229,9 @@ def publish(session: nox.Session):
     session.run("hatch", "publish", *session.posargs)
     session.run("hatch", "version", "post")
     session.run("git", "add", "src/antsibull_docs_parser/__init__.py", external=True)
-    session.run("git", "commit", "-m", "Post-release version bump.", external=True)
+    session.run(
+        "git", "commit", "-m", "Post-release version bump.", "--gpg-sign", external=True
+    )
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -206,6 +206,7 @@ def bump(session: nox.Session):
         "git",
         "tag",
         "-a",
+        "-s",
         "-m",
         f"antsibull-docs-parser {version}",
         "--edit",


### PR DESCRIPTION
Make sure that the preparation, release, and post-release commits are signed. When tagging the release commit, also sign it.